### PR TITLE
Backslash aus Pfad in Schrägstrich ersetzen

### DIFF
--- a/lib/asset_packer.php
+++ b/lib/asset_packer.php
@@ -443,6 +443,7 @@ class AssetPacker_css extends AssetPacker
         $scss_compiler->setNumberPrecision(10);
         $scss_compiler->setFormatter(\ScssPhp\ScssPhp\Formatter\Compressed::class);
         $styles = '@import \''.\rex_path::addon('be_style','plugins/redaxo/scss/_variables').'\';';
+    	$styles = str_replace('\\','/',$styles);
         return $scss_compiler->compile($styles.$content);
 	}
 


### PR DESCRIPTION
Ich hatte unter Windows (xampp php8) bei der Installation den Fehler
AddOn geolocation konnte aus folgendem Grund nicht installiert werden:
AssetPacker: "C:\www\myproject\app\redaxo\src\addons\geolocation/install/vendor/leaflet/leaflet.css" not minimized [`C:wwwmyproject ppredaxosrc૝ons¾_stylepluginsredaxoscss_variables` file not found for @import: line: 1, column: 0]! Minificaton stopped. (file C:\www\myproject\app\redaxo\src\addons\geolocation\lib\asset_packer.php line 353)
Die ergänzte Zeile löste bei mir das Problem.