### PR TITLE
Warning Undefined array key "en" beseitigt

### DIFF
--- a/lib/yform/dataset/layer.php
+++ b/lib/yform/dataset/layer.php
@@ -429,8 +429,9 @@ class layer extends \rex_yform_manager_dataset
         if (isset($lang[$locale]) && $lang[$locale]) {
             return $lang[$locale];
         }
-        if (isset($lang[array_key_first($lang)]) && $lang[array_key_first($lang)]) {
-            return $lang[array_key_first($lang)];
+        $locale = array_key_first($lang);
+        if (isset($lang[$locale]) && $lang[$locale]) {
+            return $lang[$locale];
         }
         return $this->name;
     }

--- a/lib/yform/dataset/layer.php
+++ b/lib/yform/dataset/layer.php
@@ -426,7 +426,13 @@ class layer extends \rex_yform_manager_dataset
         if( !$locale ) $locale = \rex_clang::getCurrent()->getCode();
         $lang = \rex_var::toArray( $this->lang );
         $lang = array_column( $lang,1,0 );
-        return $lang[$locale] ?: $lang[array_key_first($lang)] ?: $this->name;
+        if (isset($lang[$locale]) && $lang[$locale]) {
+            return $lang[$locale];
+        }
+        if (isset($lang[array_key_first($lang)]) && $lang[array_key_first($lang)]) {
+            return $lang[array_key_first($lang)];
+        }
+        return $this->name;
     }
 
     /**


### PR DESCRIPTION
Der Originalcode hat bei mir (mehrsprachige Seite, 1. Sprache en) eine Warning hervorgebracht:
Undefined array key "en"
Mit dem Patch kam die Warning nicht mehr zum Vorschein und alles funktioniert super.
Zugegeben, der Originalcode ist sehr viel hübscher.