### PR TITLE
0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## **20.02.2022 Version 0.15.0**
+
+- Einbinden der Standard-Assets im Backend nun auch über `tools::echoAssetTags()`
+- Event-Namen:
+    - andere Struktur; Präfix nun mit Doppelpunkt als Trennzeichen (`geolocation:`) ähnlich `rex:`
+    - alt: `geolocation.create` -> neu: `geolocation:map.ready`
+    - alt: `geolocation.setData` -> neu: `geolocation:dataset.ready`
+    - Dokumentation aktualisiert
+- neue Methode `\Geolocation\mapset->getDefaultId()`
+- In der Mapset-Liste wird der Aktions-Button "Löschen" für den Default-Mapset ausgeblendet
+- package.yml,help.yml: Permissions in '' gesetzt
+___
+
+
 ## **07.02.2022 Version 0.14.2**
 
 - Deutlichere Hinweise in Handbuch und Installation, dass in den Beispieldaten bei der Karten-URL

--- a/boot.php
+++ b/boot.php
@@ -72,10 +72,7 @@ if( \rex::isBackend() ){
         );
     }
 
-    if( LOAD ){
-        \rex_view::addCssFile($this->getAssetsUrl('geolocation.min.css'));
-        \rex_view::addJsFile($this->getAssetsUrl('geolocation.min.js'));
-    }
+    tools::echoAssetTags();
     \rex_view::addCssFile($this->getAssetsUrl('geolocation_be.min.css'));
 
 }

--- a/docs/devjs.md
+++ b/docs/devjs.md
@@ -207,14 +207,14 @@ wird die Leaflet-Karteninstanz sowie der HTML-Container der Karte (i.d.R. also e
 `<rex-map>`-Instanz) zurückgegeben.
 
 ```JS
-document.addEventListener( 'geolocation.create', function(e){
+document.addEventListener( 'geolocation:map.ready', function(e){
     console.log(e.detail.map);
     console.log(e.detail.container);
 },false);
 ```
 
 <a name="evtcreate"></a>
-### geolocation.create
+### geolocation:map.ready
 
 Die Karte kann auf Wunsch auch direkt als Leaflet-Karte ohne Zwischenschaltung von
 **Geolocation**-Tools verwaltet werden. Dazu muss die Leaflet-Instanz identifiziert werden.
@@ -224,8 +224,8 @@ wurde. Tatsächlich ist es ein verlängerter Load-Event der Leaflet-Karte.
 ```js
 this.map.on( 'load', function(e){
     ...
-    document.dispatchEvent(
-        new CustomEvent('geolocation.create', { 'detail':{'container':container, 'map':this.map} })
+    map.getContainer().dispatchEvent(
+        new CustomEvent('geolocation:map.ready', { 'detail':{'container':container, 'map':this.map} })
     );
 }, this);
 ```
@@ -238,14 +238,14 @@ werden.
 Hier ein Anwendungsbeispiel:
 
 ```JS
-document.addEventListener( 'geolocation.create', function(e){
+document.addEventListener( 'geolocation:map.ready', function(e){
     if ( 'myid' === e.detail.container.id ){
         // Leaflet-Event "zoomend" belegen
         e.detail.map.on('zoomend', function(e){
             alert( Geolocation.i18n('Zoom finished') );
         });
         // setData abfangen
-        e.detail.container.addEventListener( 'geolocation.setData', function(e){
+        e.detail.container.addEventListener( 'geolocation:dataset.ready', function(e){
             alert( Geolocation.i18n('Map updated') );
         },false);
     }
@@ -253,13 +253,13 @@ document.addEventListener( 'geolocation.create', function(e){
 ```
 
 <a name="evtsetdata"></a>
-### geolocation.setData
+### geolocation:dataset.ready
 
 Der Event wird ausgelöst, wenn der Karte ein neuer Dataset hinzugefügt wurde. Der alte Dataset wurde
 entfernt, die Tools des neuen Dataset auf die Karte geschrieben.
 
 ```JS
-document.addEventListener( 'geolocation.setData', function(e){
+document.addEventListener( 'geolocation:dataset.ready', function(e){
     if ( 'myid' === e.detail.container.id ){
         alert( Geolocation.i18n('Map updated') );
     }

--- a/docs/install.md
+++ b/docs/install.md
@@ -461,10 +461,10 @@ Die Berechtigungsverwaltung erfolgt über die Benutzer- und Rollenverwaltung in 
 |-|-|
 |admin| Darf alles, sieht alles|
 |geolocation[mapset]|Kartensätze zusammenstellen und verwalten|
-|geolocation[layer]|Kartendaten / Layer-Daten bearbeiten. Da hier die grundlegende Funktion schnellbeeinträchtigt werden kann (z.B. falsche URLs), sollte diese Berechtigung ohnehin Entwicklern und Admins vorbehalten sein.|
-|geolocation[clearcache]|Cache löschen; Das Recht bezieht sich auf per `rex_api` ausgelöstes Löschen (z.B. Lösch-Button der Addon-Seiten im Backend). Cronjobs sind nicht betroffen|
+|geolocation[layer]|Kartendaten / Layer-Daten bearbeiten. Da hier die grundlegende Funktion schnell beeinträchtigt werden kann (z.B. falsche URLs), sollte diese Berechtigung besser nicht vergeben werden. Die Berechtigung sollte Entwicklern und Admins vorbehalten sein und wäre ist in der Rollw "Admin" enthalten.|
+|geolocation[clearcache]|Cache löschen; Das Recht bezieht sich auf per `rex_api` ausgelöstes Löschen (z.B. Lösch-Button der Addon-Seiten im Backend). Cronjobs sind nicht betroffen. Die Rolle gilt summarisch für alle Caches und kann nicht auf einzelne eingegrenzt werden.|
 
-Passend dazu werden auch die Handbuchseiten eingeschränkt. Diese Installationsseite ist z.B. nur für
+Passend zur Rolle werden auch die Handbuchseiten eingeschränkt. Diese Installationsseite ist z.B. nur für
 Admins sichtbar.
 
 ## Darkmode

--- a/fragments/geolocation_rex_map.php
+++ b/fragments/geolocation_rex_map.php
@@ -47,20 +47,5 @@ if( isset($this->attributes) && is_array($this->attributes) && count($this->attr
     );
 }
 
-// Schript-Code für Events einfügen
-if( isset($this->events) && is_array($this->events) && count($this->events) ) {
-    $code = '';
-    $id = 'rm'.md5( microtime() );
-    foreach( $this->events as $k=>$v ) {
-        $exit = 'if( !e.detail.container.hasAttribute(\''.$id.'\') ) return;';
-        $code .= 'document.addEventListener(\'geolocation.'.$k.'\', function(e){'.$exit.'console.log(e);'.$v.'});';
-    }
-    if( $code ) {
-        echo '<script type="text/javascript">',$code,'</script>';
-        $attributes[$id] = 1;
-    }
-}
-
-
 // HTML-Tag generieren
 echo '<rex-map',\rex_string::buildAttributes($attributes),'></rex-map>';

--- a/help.yml
+++ b/help.yml
@@ -2,21 +2,21 @@ default:
 #    initial: i.d.R. docs/mapset.md
     permissions:
         # sperrt das verlinkte Bild in docs/layer.md für Berechtigung geolocation[mapset]
-        docs/assets/tiles_list.jpg: geolocation[layer]
-        docs/assets/tiles_edit.jpg: geolocation[layer]
+        docs/assets/tiles_list.jpg: 'geolocation[layer]'
+        docs/assets/tiles_edit.jpg: 'geolocation[layer]'
         # sperrt weitere Assets für alle Berechtigungen außer Admin[]
-        docs/assets/config.jpg: admin[]
-        docs/assets/cronjob.jpg: admin[]
+        docs/assets/config.jpg: 'admin[]'
+        docs/assets/cronjob.jpg: 'admin[]'
 
     0:
         title: ''
         icon: fa fa-info
-        perm: admin[]
+        perm: 'admin[]'
         path: readme.md
     1:
         title: translate:geolocation_manpage_install
         icon: fa fa-book
-        perm: admin[]
+        perm: 'admin[]'
         path: docs/install.md
         subnav:
             0:
@@ -29,23 +29,23 @@ default:
     2:
         title: translate:geolocation_manpage_mapset
         icon: fa fa-book
-        perm: geolocation[mapset]
+        perm: 'geolocation[mapset]'
         active: true
         path: docs/mapset.md
     3:
         title: translate:geolocation_manpage_layer
         icon: fa fa-book
-        perm: geolocation[layer]
+        perm: 'geolocation[layer]'
         path: docs/layer.md
     4:
         title: translate:geolocation_manpage_proxy
         icon: fa fa-book
-        perm: admin[]
+        perm: 'admin[]'
         path: docs/proxy_cache.md
     5:
         title: translate:geolocation_manpage_developer
         icon: fa fa-book
-        perm: admin[]
+        perm: 'admin[]'
         path: docs/devphp.md
         subnav:
             0:

--- a/install/geolocation.js
+++ b/install/geolocation.js
@@ -191,7 +191,7 @@ Geolocation.Classes.Map = class {
             if( true === Geolocation.default.mapOptions.locateControl ) {
                 this.locationTool = Geolocation.tools._currentlocation();
             }
-            container.dispatchEvent(new CustomEvent('geolocation.create', { 'detail':{'container':container, 'map':this.map},bubbles:true }));
+            container.dispatchEvent(new CustomEvent('geolocation:map.ready', { 'detail':{'container':container, 'map':this.map},bubbles:true }));
         }, this);
 
         this.layerControl = L.control.layers( );
@@ -234,7 +234,7 @@ Geolocation.Classes.Map = class {
             this.tools.push( Geolocation.tools[tool]().setValue( dataset[tool] ) );
         })
         this.tools.forEach( (t) => t.show( this.map ) );
-        this.map._container.dispatchEvent(new CustomEvent('geolocation.setData', { 'detail':{'container':this.map._container, 'map':this.map},bubbles:true }));
+        this.map._container.dispatchEvent(new CustomEvent('geolocation:dataset.ready', { 'detail':{'container':this.map._container, 'map':this.map},bubbles:true }));
     }
 
 	setMapset( mapset={}, clearLayers=true ){

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: geolocation
-version: '0.14.2'
+version: '0.15.0'
 author: Christoph Böcker
 supportpage: https://github.com/christophboecker/geolocation
 
@@ -11,15 +11,15 @@ page:
         config:
             title: translate:geolocation_config
             icon: fa fa-wrench
-            perm: admin[]
+            perm: 'admin[]'
         mapset:
             title: translate:geolocation_mapset
-            perm: geolocation[mapset]
+            perm: 'geolocation[mapset]'
             icon: fa fa-map
             subPath: pages/yform.php
         layer:
             title: translate:geolocation_layer
-            perm: geolocation[layer]
+            perm: 'geolocation[layer]'
             icon: fa fa-cloud-download
             subPath: pages/yform.php
         docs:
@@ -28,8 +28,8 @@ page:
             subPath: help.php
         clear_cache:
             title: 'translate:geolocation_clear_cache'
-            perm: geolocation[clearcache]
-            itemclass: 'pull-right'
+            perm: 'geolocation[clearcache]'
+            itemclass: pull-right
             linkclass: 'btn btn-delete'
             href:
                 # Zur Info: Die konkreten Parameter setzt kontext-bezogen pages/index.php


### PR DESCRIPTION
- Einbinden der Standard-Assets im Backend nun auch über `tools::echoAssetTags()`
- Event-Namen:
    - andere Struktur; Präfix nun mit Doppelpunkt als Trennzeichen (`geolocation:`) ähnlich `rex:`
    - alt: `geolocation.create` -> neu: `geolocation:map.ready`
    - alt: `geolocation.setData` -> neu: `geolocation:dataset.ready`
    - Dokumentation aktualisiert
- neue Methode `\Geolocation\mapset->getDefaultId()`
- In der Mapset-Liste wird der Aktions-Button "Löschen" für den Default-Mapset ausgeblendet
- package.yml,help.yml: Permissions in '' gesetzt
